### PR TITLE
fix: remove invalid storybookflags parameter from chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -82,7 +82,6 @@ jobs:
             - packages/ui/src/**
             - apps/showcase/src/**
           traceChanged: true
-          storybookFlags: '--webpack-stats-json'
 
       - name: Check snapshot usage
         if: always()


### PR DESCRIPTION
## Problem
The Chromatic workflow is failing on the main branch.

## Changes
- Removed the invalid `storybookFlags` parameter from chromatic.yml

## Testing
- ✅ Lint and type-check pass locally

Fixes the CI/CD pipeline failure on main.