### PR TITLE
ci: add commitlint workflow and config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [2, "always", ["chore", "ci", "fix", "feat", "docs", "refactor", "perf", "revert"]],
+    "subject-case": [2, "always", ["lower-case"]],
+    "header-max-length": [2, "always", 72]
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Summary
+Kurzbeschreibung …
+
+### Checklist
+- [ ] PR-Titel folgt Conventional Commits (z. B. `ci: fix deploy pipeline`)
+- [ ] CI grün (quality, deploy ggf. skipped)
+- [ ] Keine Secrets im Diff

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,29 +1,12 @@
 name: Commitlint
-
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
-
+    types: [opened, edited, synchronize, reopened]
 jobs:
-  commitlint:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: wagoid/commitlint-github-action@v6
         with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies (no frozen lockfile)
-        run: npm ci
-
-      - name: Validate PR title
-        run: echo "${{ github.event.pull_request.title }}" | npx commitlint
-
-      # Optional: Nur PR-Titel prüfen, um rebase/squash-Varianten zu tolerieren
-      # - name: Validate commits
-      #   run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose || true
+          configFile: .commitlintrc.json


### PR DESCRIPTION
### Summary
Add commitlint configuration and workflow to enforce conventional commit standards.

### Changes
- Add .commitlintrc.json with conventional commit rules
- Update commitlint workflow to use wagoid action  
- Add PR template with checklist
- Enforce max 72 char headers and lowercase subjects

### Checklist
- [x] PR-Titel folgt Conventional Commits
- [x] CI grün (quality, deploy ggf. skipped)
- [x] Keine Secrets im Diff