### PR TITLE
ci: switch quality pipeline to npm workspaces on node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: quality
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install (npm workspaces)
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
### Summary
Fix CI quality checks by switching to npm workspaces with Node 22.

### Changes
- Add quality workflow for CI checks
- Use npm ci for proper workspace installation
- Run lint, type-check and build steps
- Cache npm dependencies for faster builds

### Checklist
- [x] PR-Titel folgt Conventional Commits
- [x] CI grün (quality, deploy ggf. skipped)
- [x] Keine Secrets im Diff